### PR TITLE
[17.0] [FIX] auth_session_timeout: Added pre-migration script for inactive_session_time_out_ignored_url

### DIFF
--- a/auth_session_timeout/migrations/17.0.1.0.0/pre-migration.py
+++ b/auth_session_timeout/migrations/17.0.1.0.0/pre-migration.py
@@ -1,0 +1,12 @@
+def migrate(env, version):
+    """
+    Updates the 'inactive_session_time_out_ignored_url' parameter
+    in the 'ir_config_parameter' table during migration.
+    """
+    env.cr.execute(
+        """
+        UPDATE ir_config_parameter
+        SET value = '/calendar/notify,/websocket'
+        WHERE key = 'inactive_session_time_out_ignored_url'
+        """
+    )


### PR DESCRIPTION
Small improvement for https://github.com/OCA/server-auth/pull/646